### PR TITLE
`<Suspense>`を用いた読み込み画面を実装した

### DIFF
--- a/apps/web/src/app/[statLabel]/loading.tsx
+++ b/apps/web/src/app/[statLabel]/loading.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from 'react';
+import { Skeleton } from '@/features/navigation/components/Skeleton/Skeleton';
+import { PopulationChartSkeleton } from '@/features/population/components/PopulationChart/PopulationChart.skeleton';
+import { css } from 'styled-system/css';
+
+const GraphPageSkeleton = (): ReactElement => {
+  return (
+    <main
+      className={css({
+        w: 'full',
+        display: 'flex',
+        flexGrow: 1,
+        flexDir: 'column',
+        justifyContent: 'start',
+        alignItems: 'center',
+        overflowX: 'hidden',
+        gap: '4',
+      })}
+    >
+      <h1
+        className={css({
+          w: 'full',
+          textAlign: 'center',
+          fontFamily: 'heading',
+          fontWeight: 'bold',
+          fontSize: '2xl',
+          md: {
+            fontSize: '4xl',
+          },
+        })}
+      >
+        <Skeleton inline className={css({ w: '75%', maxW: 'full' })} />
+      </h1>
+      <PopulationChartSkeleton />
+    </main>
+  );
+};
+
+export default GraphPageSkeleton;
+
+/**
+ * ルートが再生成されるまでの時間を秒単位で指定します。
+ * @see https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
+ */
+export const revalidate = false; // 再生成しない

--- a/apps/web/src/app/[statLabel]/page.tsx
+++ b/apps/web/src/app/[statLabel]/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
 import type { ReactElement } from 'react';
+import { Suspense } from 'react';
+import { PopulationChart } from '@/features/population/components/PopulationChart/PopulationChart';
+import { PopulationChartSkeleton } from '@/features/population/components/PopulationChart/PopulationChart.skeleton';
 import { fetchPrefectures } from '@/infra/resas/fetchPrefectures';
-import { extractDataPointsByStatLabel } from '@/libs/extractDataPointsByStatLabel';
 import { getGraphPageTitleLocaleJa } from '@/libs/getGraphPageTitleLocale';
-import { getPopulationCompositionAll } from '@/libs/getPopulationCompositionAll';
 import type { PrefCode } from '@/models/prefCode';
 import { prefCodesSchema } from '@/models/prefCode';
 import { statLabelSchema } from '@/models/statLabel';
@@ -24,10 +25,10 @@ const GraphPage = async ({ params, searchParams }: GraphPageProps): Promise<Reac
           .flat()
       : [],
   ) as PrefCode[];
-  const record = await getPopulationCompositionAll(prefCodes);
-  const dataPoints = extractDataPointsByStatLabel(record, statLabel);
+
   const { prefLocaleJa } = await fetchPrefectures();
   const title = getGraphPageTitleLocaleJa(prefLocaleJa, prefCodes, statLabel);
+
   return (
     <main
       className={css({
@@ -53,15 +54,9 @@ const GraphPage = async ({ params, searchParams }: GraphPageProps): Promise<Reac
       >
         {title}
       </h1>
-      <p
-        className={css({
-          fontFamily: 'monospace',
-          fontSize: 'sm',
-          color: 'keyplate.11',
-        })}
-      >
-        {JSON.stringify(dataPoints, null, 2)}
-      </p>
+      <Suspense key={title} fallback={<PopulationChartSkeleton />}>
+        <PopulationChart statLabel={statLabel} prefCodes={prefCodes} />
+      </Suspense>
     </main>
   );
 };

--- a/apps/web/src/features/navigation/components/PrefectureForm/PrefectureForm.tsx
+++ b/apps/web/src/features/navigation/components/PrefectureForm/PrefectureForm.tsx
@@ -55,7 +55,9 @@ export const PrefectureForm = async ({ className, ...props }: PrefectureFormProp
               gridTemplateColumns: '1fr 1fr 1fr',
             })}
           >
-            <Skeleton lines={5} className={css({ w: 'full' })} />
+            {Array.from({ length: 47 }, (_, i) => (
+              <Skeleton key={i} inline={false} className={css({ w: 'auto', h: '8', m: '1' })} />
+            ))}
           </fieldset>
         }
       >

--- a/apps/web/src/features/population/components/PopulationChart/PopulationChart.skeleton.tsx
+++ b/apps/web/src/features/population/components/PopulationChart/PopulationChart.skeleton.tsx
@@ -1,0 +1,25 @@
+import type { ReactElement } from 'react';
+import type { PopulationChartProps } from './PopulationChart';
+import { Skeleton } from '@/features/navigation/components/Skeleton/Skeleton';
+import { css, cx } from 'styled-system/css';
+
+export type PopulationChartSkeletonProps = Omit<PopulationChartProps, 'prefCodes' | 'statLabel'>;
+
+export const PopulationChartSkeleton = ({ className, ...props }: PopulationChartSkeletonProps): ReactElement => {
+  return (
+    <p
+      className={cx(
+        css({
+          w: 'full',
+          fontFamily: 'monospace',
+          fontSize: 'sm',
+          color: 'keyplate.11',
+        }),
+        className,
+      )}
+      {...props}
+    >
+      <Skeleton inline lines={14} className={css({ w: 'full' })} />
+    </p>
+  );
+};

--- a/apps/web/src/features/population/components/PopulationChart/PopulationChart.tsx
+++ b/apps/web/src/features/population/components/PopulationChart/PopulationChart.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement } from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
+import { extractDataPointsByStatLabel } from '@/libs/extractDataPointsByStatLabel';
+import { getPopulationCompositionAll } from '@/libs/getPopulationCompositionAll';
+import type { PrefCode } from '@/models/prefCode';
+import type { StatLabel } from '@/models/statLabel';
+import { css, cx } from 'styled-system/css';
+
+export type PopulationChartProps = Omit<ComponentPropsWithoutRef<'p'>, 'children'> & {
+  statLabel: StatLabel;
+  prefCodes: PrefCode[];
+};
+
+export const PopulationChart = async ({
+  statLabel,
+  prefCodes,
+  className,
+  ...props
+}: PopulationChartProps): Promise<ReactElement> => {
+  const record = await getPopulationCompositionAll(prefCodes);
+  const dataPoints = extractDataPointsByStatLabel(record, statLabel);
+  return (
+    <p
+      className={cx(
+        css({
+          fontFamily: 'monospace',
+          fontSize: 'sm',
+          color: 'keyplate.11',
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {JSON.stringify(dataPoints, null, 2)}
+    </p>
+  );
+};
+
+// /**
+//  * ルートが再生成されるまでの時間を秒単位で指定します。
+//  * @see https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
+//  */
+// export const revalidate = 3600 * 24; // 24時間


### PR DESCRIPTION
- close #28

- refactor: ♻️ (`/[statLabel]`) グラフ部分を`<PopulationChart>`に分割して読み込み表示を追加した。  (#28)
- feat: ✨ (`/[statLabel]`) ルート全体の読み込み表示を追加した。  (#28)
- fix: 🐛 (`<PrefectureForm>`) 読み込み表示の見た目を実際のものにより近くした。  (#28)

https://github.com/ReoHakase/simple-resas-app/assets/16751535/d1868cdc-166a-40a6-aa94-0d688a3ada34

