### PR TITLE
線グラフを描画する`<Chart>` `<PopulationChart>`を実装した

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "5.0.1",
+    "recharts": "2.12.7",
     "zod": "3.22.4"
   },
   "devDependencies": {

--- a/apps/web/panda.config.ts
+++ b/apps/web/panda.config.ts
@@ -189,7 +189,16 @@ export default defineConfig({
         danger: 'crimson',
       },
       colorScales: ['white', 'black'],
-      withoutAlpha: false,
+      excludeAlpha: false,
+    }),
+    radixColorsPreset({
+      darkMode: {
+        // NOTE: Make sure these selectors match the configurations passed to `next-themes` ThemeProvider
+        condition: "[data-theme='dark'] &",
+      },
+      autoP3: true,
+      excludeAlpha: true,
+      excludedShades: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12], // 11 以外
     }),
 
     radixUIPreset({

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -54,9 +54,6 @@ const RootLayout: FC<RootLayoutProps> = ({ children }) => (
               flexDir: 'column',
               p: '6',
               flexGrow: '3',
-              lgDown: {
-                h: '440px', // CLS防止
-              },
             })}
           >
             {children}

--- a/apps/web/src/components/Chart/Chart.stories.tsx
+++ b/apps/web/src/components/Chart/Chart.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Chart } from './Chart';
+import type { ChartProps } from './Chart';
+import { css } from 'styled-system/css';
+
+const chartProps: ChartProps<'year', 'apple' | 'banana' | 'grape'> = {
+  dataKey: 'year',
+  unitX: '年',
+  unitY: '個',
+  series: [
+    {
+      name: 'apple',
+      label: 'りんご',
+      color: 'red',
+    },
+    {
+      name: 'banana',
+      label: 'バナナ',
+      color: 'amber',
+    },
+    {
+      name: 'grape',
+      label: 'ぶどう',
+      color: 'purple',
+    },
+  ],
+  data: [
+    {
+      year: '1960',
+      apple: 100,
+      banana: 200,
+      grape: 300,
+    },
+    {
+      year: '1965',
+      apple: 104,
+      banana: 190,
+      grape: 305,
+    },
+    {
+      year: '1970',
+      apple: 97,
+      banana: 130,
+      grape: 290,
+    },
+    {
+      year: '1975',
+      apple: 122,
+      banana: 150,
+      grape: 215,
+    },
+    {
+      year: '1980',
+      apple: 119,
+      banana: 162,
+      grape: 420,
+    },
+    {
+      year: '1985',
+      apple: 127,
+      banana: 250,
+      grape: 325,
+    },
+    {
+      year: '1990',
+      apple: 174,
+      banana: 180,
+      grape: 340,
+    },
+    {
+      year: '1995',
+      apple: 128,
+      banana: 130,
+      grape: 335,
+    },
+    {
+      year: '2000',
+      apple: 132,
+      banana: 120,
+      grape: 340,
+    },
+    {
+      year: '2005',
+      apple: 236,
+      banana: 150,
+      grape: 375,
+    },
+    {
+      year: '2010',
+      apple: 140,
+      banana: 100,
+      grape: 350,
+    },
+    {
+      year: '2015',
+      apple: 164,
+      banana: 10,
+      grape: 255,
+    },
+    {
+      year: '2020',
+      apple: 148,
+      banana: 80,
+      grape: 360,
+    },
+  ],
+};
+
+type Story = StoryObj<typeof Chart>;
+
+const meta: Meta<typeof Chart> = {
+  component: Chart,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className={css({ w: 'full', h: '500px' })}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: chartProps as ChartProps<string, string>,
+};
+
+export default meta;
+
+export const Default: Story = {};

--- a/apps/web/src/components/Chart/Chart.tsx
+++ b/apps/web/src/components/Chart/Chart.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import { css } from 'styled-system/css';
+import { token } from 'styled-system/tokens';
+import type { LineColor } from './lineColors';
+import { lineColorsRecord } from './lineColors';
+
+const formatNumber = new Intl.NumberFormat('ja-JP', { notation: 'compact' }).format;
+
+export type ChartProps<X extends string, Y extends string> = {
+  data: Array<Record<X, string | number> & Record<Y, number | null>>;
+  dataKey: X;
+  unitX?: string;
+  unitY?: string;
+  labelX?: string;
+  labelY?: string;
+  formatNumbers?: boolean;
+  series: Array<{
+    name: Y;
+    label: string;
+    color: LineColor;
+  }>;
+};
+
+/**
+ * チャートコンポーネントです。
+ *
+ * @template X - X軸のデータのキー
+ * @template Y - Y軸のデータのキーの配列
+ * @param data - チャートに表示するデータ
+ * @param dataKey - X軸のデータキー
+ * @param series - Y軸のデータの色とラベルの設定
+ * @returns チャートコンポーネントのReact要素
+ */
+export const Chart = <X extends string, Y extends string>({
+  unitX,
+  unitY,
+  labelX,
+  labelY,
+  formatNumbers,
+  data,
+  dataKey,
+  series,
+}: ChartProps<X, Y>): ReactNode => {
+  return (
+    <ResponsiveContainer
+      width="100%"
+      height="100%"
+      className={css({
+        color: 'keyplate.11',
+      })}
+    >
+      <LineChart data={data}>
+        <CartesianGrid strokeDasharray="4 4" fill={token('colors.keyplate.a.2')} stroke={token('colors.keyplate.6')} />
+        <XAxis
+          dataKey={dataKey}
+          tick={{ fill: token('colors.keyplate.11') }}
+          unit={unitX}
+          label={labelX}
+          tickFormatter={formatNumbers ? formatNumber : undefined}
+        />
+        <YAxis
+          tick={{ fill: token('colors.keyplate.11') }}
+          unit={unitY}
+          label={labelY}
+          tickFormatter={formatNumbers ? formatNumber : undefined}
+        />
+        <Tooltip
+          contentStyle={{
+            background: token('colors.keyplate.1'),
+            borderRadius: token('radii.lg'),
+            border: '1px solid',
+            borderColor: token('colors.keyplate.6'),
+            display: 'flex',
+            flexDirection: 'column',
+            paddingInline: token('sizes.3'),
+            paddingBlock: token('sizes.2'),
+            gap: token('sizes.1'),
+          }}
+        />
+        <Legend />
+        {series.map(({ name, label, color }) => (
+          <Line
+            key={name}
+            type="monotone"
+            dataKey={name}
+            name={label}
+            stroke={lineColorsRecord[color]}
+            strokeWidth={2}
+            animationEasing="ease-in"
+            animationDuration={250}
+            dot={true}
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};

--- a/apps/web/src/components/Chart/Chart.tsx
+++ b/apps/web/src/components/Chart/Chart.tsx
@@ -2,10 +2,10 @@
 
 import type { ReactNode } from 'react';
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
-import { css } from 'styled-system/css';
-import { token } from 'styled-system/tokens';
 import type { LineColor } from './lineColors';
 import { lineColorsRecord } from './lineColors';
+import { css } from 'styled-system/css';
+import { token } from 'styled-system/tokens';
 
 const formatNumber = new Intl.NumberFormat('ja-JP', { notation: 'compact' }).format;
 

--- a/apps/web/src/components/Chart/lineColors.tsx
+++ b/apps/web/src/components/Chart/lineColors.tsx
@@ -1,0 +1,51 @@
+import { token } from 'styled-system/tokens';
+
+/**
+ * ラインの色の定義。
+ * アプリのカラーパレットにも採用しているRadix Colorsのスケール11を使用しています。
+ * @see https://www.radix-ui.com/colors
+ * @see https://recharts.org/en-US/api/Line#stroke
+ */
+export const lineColorsRecord = {
+  tomato: token('colors.tomato.11'),
+  red: token('colors.red.11'),
+  ruby: token('colors.ruby.11'),
+  crimson: token('colors.crimson.11'),
+  pink: token('colors.pink.11'),
+  plum: token('colors.plum.11'),
+  purple: token('colors.purple.11'),
+  violet: token('colors.violet.11'),
+  iris: token('colors.iris.11'),
+  indigo: token('colors.indigo.11'),
+  blue: token('colors.blue.11'),
+  cyan: token('colors.cyan.11'),
+  teal: token('colors.teal.11'),
+  jade: token('colors.jade.11'),
+  green: token('colors.green.11'),
+  grass: token('colors.grass.11'),
+  bronze: token('colors.bronze.11'),
+  gold: token('colors.gold.11'),
+  brown: token('colors.brown.11'),
+  orange: token('colors.orange.11'),
+  amber: token('colors.amber.11'),
+  yellow: token('colors.yellow.11'),
+  lime: token('colors.lime.11'),
+  mint: token('colors.mint.11'),
+  sky: token('colors.sky.11'),
+} as const satisfies Record<string, string>;
+
+export type LineColor = keyof typeof lineColorsRecord;
+
+export const getUniqueLineColor = (key: string): LineColor => {
+  // Create an array of the keys (colors) from lineColorsRecord
+  const colorKeys: LineColor[] = Object.keys(lineColorsRecord) as LineColor[];
+
+  // Basic hash function to convert the key string into an index
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) % colorKeys.length;
+  }
+
+  // Return the color at the index determined by the hash
+  return colorKeys[hash];
+};

--- a/apps/web/src/features/population/components/PopulationChart/PopulationChart.skeleton.tsx
+++ b/apps/web/src/features/population/components/PopulationChart/PopulationChart.skeleton.tsx
@@ -1,25 +1,40 @@
 import type { ReactElement } from 'react';
 import type { PopulationChartProps } from './PopulationChart';
-import { Skeleton } from '@/features/navigation/components/Skeleton/Skeleton';
 import { css, cx } from 'styled-system/css';
+import { Loader } from 'lucide-react';
 
 export type PopulationChartSkeletonProps = Omit<PopulationChartProps, 'prefCodes' | 'statLabel'>;
 
 export const PopulationChartSkeleton = ({ className, ...props }: PopulationChartSkeletonProps): ReactElement => {
   return (
-    <p
-      className={cx(
-        css({
-          w: 'full',
-          fontFamily: 'monospace',
-          fontSize: 'sm',
-          color: 'keyplate.11',
-        }),
-        className,
-      )}
-      {...props}
+    <div
+      className={css({
+        w: 'full',
+        h: '600px',
+        mdDown: {
+          h: '400px',
+        },
+        animation: 'pulse',
+        bg: 'keyplate.a.2',
+        rounded: '2xl',
+        ring: 'none',
+        userSelect: 'none',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      })}
     >
-      <Skeleton inline lines={14} className={css({ w: 'full' })} />
-    </p>
+      <Loader
+        className={cx(
+          css({
+            w: '8',
+            h: '8',
+            color: 'keyplate.a.9',
+            animation: 'spin',
+          }),
+          className,
+        )}
+      />
+    </div>
   );
 };

--- a/apps/web/src/features/population/components/PopulationChart/PopulationChart.skeleton.tsx
+++ b/apps/web/src/features/population/components/PopulationChart/PopulationChart.skeleton.tsx
@@ -1,9 +1,8 @@
-import type { ReactElement } from 'react';
-import type { PopulationChartProps } from './PopulationChart';
-import { css, cx } from 'styled-system/css';
 import { Loader } from 'lucide-react';
+import type { ReactElement, ComponentPropsWithoutRef } from 'react';
+import { css, cx } from 'styled-system/css';
 
-export type PopulationChartSkeletonProps = Omit<PopulationChartProps, 'prefCodes' | 'statLabel'>;
+export type PopulationChartSkeletonProps = Omit<ComponentPropsWithoutRef<'div'>, 'children'>;
 
 export const PopulationChartSkeleton = ({ className, ...props }: PopulationChartSkeletonProps): ReactElement => {
   return (
@@ -23,6 +22,7 @@ export const PopulationChartSkeleton = ({ className, ...props }: PopulationChart
         justifyContent: 'center',
         alignItems: 'center',
       })}
+      {...props}
     >
       <Loader
         className={cx(

--- a/apps/web/src/features/population/components/PopulationChart/PopulationChart.tsx
+++ b/apps/web/src/features/population/components/PopulationChart/PopulationChart.tsx
@@ -1,14 +1,14 @@
 import type { ReactElement } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
+import { Chart } from '@/components/Chart/Chart';
+import type { ChartProps } from '@/components/Chart/Chart';
+import { getUniqueLineColor } from '@/components/Chart/lineColors';
+import { fetchPrefectures } from '@/infra/resas/fetchPrefectures';
 import { extractDataPointsByStatLabel } from '@/libs/extractDataPointsByStatLabel';
 import { getPopulationCompositionAll } from '@/libs/getPopulationCompositionAll';
 import type { PrefCode } from '@/models/prefCode';
 import type { StatLabel } from '@/models/statLabel';
 import { css, cx } from 'styled-system/css';
-import { Chart } from '@/components/Chart/Chart';
-import { getUniqueLineColor } from '@/components/Chart/lineColors';
-import type { ChartProps } from '@/components/Chart/Chart';
-import { fetchPrefectures } from '@/infra/resas/fetchPrefectures';
 
 export type PopulationChartProps = Omit<ComponentPropsWithoutRef<'div'>, 'children'> & {
   statLabel: StatLabel;

--- a/apps/web/src/features/population/components/PopulationChart/PopulationChart.tsx
+++ b/apps/web/src/features/population/components/PopulationChart/PopulationChart.tsx
@@ -5,8 +5,12 @@ import { getPopulationCompositionAll } from '@/libs/getPopulationCompositionAll'
 import type { PrefCode } from '@/models/prefCode';
 import type { StatLabel } from '@/models/statLabel';
 import { css, cx } from 'styled-system/css';
+import { Chart } from '@/components/Chart/Chart';
+import { getUniqueLineColor } from '@/components/Chart/lineColors';
+import type { ChartProps } from '@/components/Chart/Chart';
+import { fetchPrefectures } from '@/infra/resas/fetchPrefectures';
 
-export type PopulationChartProps = Omit<ComponentPropsWithoutRef<'p'>, 'children'> & {
+export type PopulationChartProps = Omit<ComponentPropsWithoutRef<'div'>, 'children'> & {
   statLabel: StatLabel;
   prefCodes: PrefCode[];
 };
@@ -17,22 +21,39 @@ export const PopulationChart = async ({
   className,
   ...props
 }: PopulationChartProps): Promise<ReactElement> => {
-  const record = await getPopulationCompositionAll(prefCodes);
+  const [prefLocaleJa, record] = await Promise.all([
+    fetchPrefectures().then((data) => data.prefLocaleJa),
+    getPopulationCompositionAll(prefCodes),
+  ]);
   const dataPoints = extractDataPointsByStatLabel(record, statLabel);
+  const chartProps: ChartProps<'year', string> = {
+    data: dataPoints,
+    dataKey: 'year',
+    unitX: '年',
+    unitY: '', // モバイル表示向けに非表示
+    formatNumbers: true, // ~~万, ~~億 などにフォーマット
+    series: prefCodes.map((prefCode) => ({
+      name: prefCode,
+      label: prefLocaleJa[prefCode],
+      color: getUniqueLineColor(prefCode),
+    })),
+  };
   return (
-    <p
+    <div
       className={cx(
         css({
-          fontFamily: 'monospace',
-          fontSize: 'sm',
-          color: 'keyplate.11',
+          w: 'full',
+          h: '600px',
+          mdDown: {
+            h: '400px',
+          },
         }),
         className,
       )}
       {...props}
     >
-      {JSON.stringify(dataPoints, null, 2)}
-    </p>
+      <Chart {...chartProps} />
+    </div>
   );
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       react-icons:
         specifier: 5.0.1
         version: 5.0.1(react@18.2.0)
+      recharts:
+        specifier: 2.12.7
+        version: 2.12.7(react-dom@18.2.0)(react@18.2.0)
       zod:
         specifier: 3.22.4
         version: 3.22.4
@@ -5331,6 +5334,48 @@ packages:
       '@types/node': 18.19.1
     dev: true
 
+  /@types/d3-array@3.2.1:
+    resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
+    dev: false
+
+  /@types/d3-color@3.1.3:
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+    dev: false
+
+  /@types/d3-ease@3.0.2:
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+    dev: false
+
+  /@types/d3-interpolate@3.0.4:
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+    dependencies:
+      '@types/d3-color': 3.1.3
+    dev: false
+
+  /@types/d3-path@3.1.0:
+    resolution: {integrity: sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ==}
+    dev: false
+
+  /@types/d3-scale@4.0.8:
+    resolution: {integrity: sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==}
+    dependencies:
+      '@types/d3-time': 3.0.3
+    dev: false
+
+  /@types/d3-shape@3.1.6:
+    resolution: {integrity: sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==}
+    dependencies:
+      '@types/d3-path': 3.1.0
+    dev: false
+
+  /@types/d3-time@3.0.3:
+    resolution: {integrity: sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw==}
+    dev: false
+
+  /@types/d3-timer@3.0.2:
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+    dev: false
+
   /@types/detect-port@1.3.5:
     resolution: {integrity: sha512-Rf3/lB9WkDfIL9eEKaSYKc+1L/rNVYBjThk22JTqQw0YozXarX8YljFAz+HCoC6h4B4KwCMsBPZHaFezwT4BNA==}
     dev: true
@@ -7442,6 +7487,11 @@ packages:
     engines: {node: '>=0.8'}
     dev: true
 
+  /clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+    dev: false
+
   /co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -7916,6 +7966,77 @@ packages:
       fs-exists-sync: 0.1.0
     dev: true
 
+  /d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+    dependencies:
+      internmap: 2.0.3
+    dev: false
+
+  /d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-color: 3.1.0
+    dev: false
+
+  /d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+    dev: false
+
+  /d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-path: 3.1.0
+    dev: false
+
+  /d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-time: 3.1.0
+    dev: false
+
+  /d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-array: 3.2.4
+    dev: false
+
+  /d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+    dev: false
+
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: false
@@ -8007,6 +8128,10 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+    dev: false
 
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
@@ -8317,6 +8442,13 @@ packages:
     dependencies:
       utila: 0.4.0
     dev: true
+
+  /dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+    dependencies:
+      '@babel/runtime': 7.24.5
+      csstype: 3.1.3
+    dev: false
 
   /dom-serializer@0.2.2:
     resolution: {integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==}
@@ -9301,6 +9433,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    dev: false
+
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
     dev: true
@@ -9497,6 +9633,11 @@ packages:
 
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+    dev: false
+
+  /fast-equals@5.0.1:
+    resolution: {integrity: sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==}
+    engines: {node: '>=6.0.0'}
     dev: false
 
   /fast-fifo@1.3.2:
@@ -10625,6 +10766,11 @@ packages:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.0.6
+
+  /internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /into-stream@3.1.0:
     resolution: {integrity: sha512-TcdjPibTksa1NQximqep2r17ISRiNE9fwlfbg3F8ANdvP5/yrFTew86VcO//jk4QTaMlbjypPBq76HN2zaKfZQ==}
@@ -14308,6 +14454,19 @@ packages:
       use-sidecar: 1.1.2(@types/react@18.2.52)(react@18.2.0)
     dev: false
 
+  /react-smooth@4.0.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      fast-equals: 5.0.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
+    dev: false
+
   /react-style-singleton@2.2.1(@types/react@18.2.52)(react@18.2.0):
     resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
     engines: {node: '>=10'}
@@ -14323,6 +14482,20 @@ packages:
       invariant: 2.2.4
       react: 18.2.0
       tslib: 2.6.2
+    dev: false
+
+  /react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+    dependencies:
+      '@babel/runtime': 7.24.5
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react@18.2.0:
@@ -14419,6 +14592,31 @@ packages:
       tiny-invariant: 1.3.3
       tslib: 2.6.2
     dev: true
+
+  /recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+    dependencies:
+      decimal.js-light: 2.5.1
+    dev: false
+
+  /recharts@2.12.7(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-is: 16.13.1
+      react-smooth: 4.0.1(react-dom@18.2.0)(react@18.2.0)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
+    dev: false
 
   /redent@1.0.0:
     resolution: {integrity: sha512-qtW5hKzGQZqKoh6JNSD+4lfitfPKGz42e6QwiRmPM5mmKtR0N41AbJRYu0xJi7nhOJ4WDgRkKvAk6tw4WIwR4g==}
@@ -15761,7 +15959,6 @@ packages:
 
   /tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
-    dev: true
 
   /tinybench@2.8.0:
     resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
@@ -16464,6 +16661,25 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
     dev: true
+
+  /victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+    dependencies:
+      '@types/d3-array': 3.2.1
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.8
+      '@types/d3-shape': 3.1.6
+      '@types/d3-time': 3.0.3
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+    dev: false
 
   /vite-node@1.6.0(@types/node@18.19.1):
     resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}


### PR DESCRIPTION
- close #17

- build: 📦️ (web) グラフ描画用ライブラリ`recharts`を導入した。  (#17)
- feat: ✨ (panda-preset-radix-colors) 特定の明るさの色だけを使用できるオプションを追加した。  (#17)
- chore: 🔧 (web) グラフの線で使用する様々な色をトークンに追加した。  (#17)
- feat: ✨ (`<Chart>`) 文字列のキーからグラフの線の色を決定する関数を実装した。  (#17)
- feat: ✨ (`<Chart>`) 線グラフを表示するコンポーネントを実装した。  (#17)
- test: 🧪 (`<Chart>`) 線グラフを表示するコンポーネントのストーリーを追加した。  (#17)
- feat: ✨ (`<PopulationChart>`) 人口推移をグラフで表示するようにした。  (#17)
- refactor: ♻️ (`/` `/[statLabel]`) モバイル向けのCLS防止の固定長指定を削除した。  (#17)

## 概要

人口推移をグラフで表示するようにした。
また、読み込み画面もグラフの見た目に沿ったものに変更した。

<img width="1145" alt="image" src="https://github.com/ReoHakase/simple-resas-app/assets/16751535/541e4be4-964e-4039-a88f-607303e37cd3">

