### PR TITLE
CSSとフォントの読み込みを最適化した

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,6 +41,7 @@
     "@funboxteam/optimizt": "5.0.2",
     "@next/env": "14.2.3",
     "@pandacss/dev": "0.36.1",
+    "@pandacss/preset-panda": "0.39.2",
     "@playwright/test": "1.44.1",
     "@radix-ui/colors": "3.0.0",
     "@storybook/addon-a11y": "8.0.5",

--- a/apps/web/panda.config.ts
+++ b/apps/web/panda.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@pandacss/dev';
+import pandaPreset from '@pandacss/preset-panda';
 import { radixColorsPreset } from 'panda-preset-radix-colors';
 import { radixUIPreset } from 'panda-preset-radix-ui';
 import { checkboxSlotRecipe } from '@/components/Checkbox/Checkbox.recipe';
@@ -6,14 +7,17 @@ import { selectSlotRecipe } from '@/components/Select/Select.recipe';
 import { prefectureCheckboxSlotRecipe } from '@/features/navigation/components/PrefectureCheckbox/PrefectureCheckbox.recipe';
 import { breakpoints } from '@/styles/tokens/breakpoints';
 
+// デフォルトのプリセットから色を削除する
+pandaPreset.theme.tokens.colors = {} as typeof pandaPreset.theme.tokens.colors;
+
 export default defineConfig({
-  // Whether to use css reset
+  // CSSリセットを適用するかどうか
   preflight: true,
 
-  // Where to look for your css declarations
+  // CSS定義を探査するパス
   include: ['./src/**/*.{js,jsx,ts,tsx}'],
 
-  // Files to exclude
+  // CSS定義をの探査対象から除外するパス
   exclude: [],
 
   utilities: {
@@ -121,10 +125,6 @@ export default defineConfig({
           heading: {
             value: 'var(--font-cal-sans), sans-serif', // Make sure that the variable's name matches the one in apps/web/src/styles/fonts/index.ts
           },
-          code: {
-            value:
-              'ui-monospace,"Liga SFMono Nerd Font",SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace',
-          },
         },
         shadows: {
           floating: {
@@ -152,11 +152,10 @@ export default defineConfig({
 
   // Presets
   presets: [
-    // Radix Scales provider for PandaCSS by milandekruijf
-    // Refer: https://github.com/milandekruijf/pandacss-preset-radix-colors
+    // Radix Colorsの色トークンを追加するプリセット
     radixColorsPreset({
       darkMode: {
-        // NOTE: Make sure these selectors match the configurations passed to `next-themes` ThemeProvider
+        //  `next-themes`のプロバイダに与えた設定と整合性を保つようにする
         condition: "[data-theme='dark'] &",
       },
       autoP3: true,
@@ -164,16 +163,13 @@ export default defineConfig({
         keyplate: 'slate',
         primary: 'pink',
         info: 'cyan',
-        success: 'green',
-        warning: 'amber',
-        danger: 'crimson',
       },
-      colorScales: ['white', 'black'],
+      colorScales: [],
       excludeAlpha: false,
     }),
     radixColorsPreset({
       darkMode: {
-        // NOTE: Make sure these selectors match the configurations passed to `next-themes` ThemeProvider
+        //  `next-themes`のプロバイダに与えた設定と整合性を保つようにする
         condition: "[data-theme='dark'] &",
       },
       autoP3: true,
@@ -186,13 +182,11 @@ export default defineConfig({
       selectorNameCase: 'camelCase',
     }),
 
-    // Re-add the panda preset if you want to keep
-    // the default keyframes, breakpoints, tokens
-    // and textStyles provided by PandaCSS
-    '@pandacss/preset-panda',
+    // デフォルトのキーフレーム、ブレークポイント、トークン、テキストスタイルを保持したい場合は、パンダプリセットを再追加してください
+    pandaPreset,
   ],
 
-  // The output directory for your css system
+  // CSSシステムの出力先
   outdir: 'styled-system',
   jsxFramework: 'react',
 });

--- a/apps/web/panda.config.ts
+++ b/apps/web/panda.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from '@pandacss/dev';
 import { radixColorsPreset } from 'panda-preset-radix-colors';
 import { radixUIPreset } from 'panda-preset-radix-ui';
+import { checkboxSlotRecipe } from '@/components/Checkbox/Checkbox.recipe';
 import { selectSlotRecipe } from '@/components/Select/Select.recipe';
+import { prefectureCheckboxSlotRecipe } from '@/features/navigation/components/PrefectureCheckbox/PrefectureCheckbox.recipe';
 import { breakpoints } from '@/styles/tokens/breakpoints';
 
 export default defineConfig({
@@ -133,6 +135,8 @@ export default defineConfig({
       breakpoints: breakpoints,
       recipes: {
         select: selectSlotRecipe,
+        checkbox: checkboxSlotRecipe,
+        prefectureCheckbox: prefectureCheckboxSlotRecipe,
       },
     },
   },

--- a/apps/web/src/components/Checkbox/Checkbox.recipe.ts
+++ b/apps/web/src/components/Checkbox/Checkbox.recipe.ts
@@ -1,0 +1,58 @@
+import { defineSlotRecipe as sva } from '@pandacss/dev';
+
+export const checkboxSlotRecipe = sva({
+  className: 'checkbox',
+  description: 'チェックボックスのスタイル',
+  jsx: ['Checkbox'],
+  slots: ['label', 'check', 'input'],
+  base: {
+    label: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      w: '8',
+      h: '8',
+      rounded: 'sm',
+      border: '1px solid',
+      borderColor: 'keyplate.6',
+      bg: 'keyplate.2',
+      cursor: 'pointer',
+      '&:has(+ input:focus-visible)': {
+        ringColor: 'cyan.9',
+        ringWidth: '2',
+        outlineStyle: 'solid',
+        ringOffset: '2px',
+      },
+      '&:has(+ input:checked)': {
+        bg: 'primary.3',
+        borderColor: 'primary.9',
+        color: 'primary.11',
+      },
+      '&:has(+ input:disabled)': {
+        bg: 'keyplate.4',
+        color: 'keyplate.11',
+        cursor: 'not-allowed',
+      },
+      '&:has(+ input:checked:disabled)': {
+        bg: 'keyplate.4',
+        color: 'keyplate.11',
+        borderColor: 'keyplate.9',
+      },
+      _hover: {
+        bg: 'keyplate.3',
+      },
+    },
+    check: {
+      'label:has(+ input:not(:checked)) &': {
+        display: 'none',
+      },
+    },
+    input: {
+      appearance: 'none',
+      pos: 'absolute',
+      top: '0',
+      left: '0',
+      pointerEvents: 'none',
+    },
+  },
+});

--- a/apps/web/src/components/Checkbox/Checkbox.tsx
+++ b/apps/web/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,7 @@
 import { Check } from 'lucide-react';
 import { ComponentPropsWithoutRef, forwardRef, ReactNode } from 'react';
-import { css, cx } from 'styled-system/css';
+import { cx } from 'styled-system/css';
+import { checkbox } from 'styled-system/recipes';
 
 export type CheckboxProps = Omit<ComponentPropsWithoutRef<'input'>, 'type'> & {
   id: string; // <label>で擬似的なチェックボックスを作るために必要
@@ -8,6 +9,7 @@ export type CheckboxProps = Omit<ComponentPropsWithoutRef<'input'>, 'type'> & {
 };
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(({ id, className, ...props }, ref): ReactNode => {
+  const { label, check, input } = checkbox();
   return (
     <>
       <label
@@ -15,67 +17,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(({ id, class
         // a11yテストで、labelが複数存在するエラーを防ぐためにaria-hiddenを指定する。実際のlabelのidをaria-labelledbyで指定する
         // @see https://dequeuniversity.com/rules/axe/4.9/form-field-multiple-labels
         aria-hidden="true"
-        className={cx(
-          css({
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            w: '8',
-            h: '8',
-            rounded: 'sm',
-            border: '1px solid',
-            borderColor: 'keyplate.6',
-            bg: 'keyplate.2',
-            cursor: 'pointer',
-            '&:has(+ input:focus-visible)': {
-              ringColor: 'cyan.9',
-              ringWidth: '2',
-              outlineStyle: 'solid',
-              ringOffset: '2px',
-            },
-            '&:has(+ input:checked)': {
-              bg: 'primary.3',
-              borderColor: 'primary.9',
-              color: 'primary.11',
-            },
-            '&:has(+ input:disabled)': {
-              bg: 'keyplate.4',
-              color: 'keyplate.11',
-              cursor: 'not-allowed',
-            },
-            '&:has(+ input:checked:disabled)': {
-              bg: 'keyplate.4',
-              color: 'keyplate.11',
-              borderColor: 'keyplate.9',
-            },
-            _hover: {
-              bg: 'keyplate.3',
-            },
-          }),
-          className,
-        )}
+        className={cx(label, className)}
       >
-        <Check
-          className={css({
-            'label:has(+ input:not(:checked)) &': {
-              display: 'none',
-            },
-          })}
-        />
+        <Check className={check} />
       </label>
-      <input
-        id={id}
-        type="checkbox"
-        ref={ref}
-        className={css({
-          appearance: 'none',
-          pos: 'absolute',
-          top: '0',
-          left: '0',
-          pointerEvents: 'none',
-        })}
-        {...props}
-      />
+      <input id={id} type="checkbox" ref={ref} className={input} {...props} />
     </>
   );
 });

--- a/apps/web/src/features/navigation/components/PrefectureCheckbox/PrefectureCheckbox.recipe.tsx
+++ b/apps/web/src/features/navigation/components/PrefectureCheckbox/PrefectureCheckbox.recipe.tsx
@@ -1,0 +1,42 @@
+import { defineSlotRecipe as sva } from '@pandacss/dev';
+
+export const prefectureCheckboxSlotRecipe = sva({
+  className: 'prefecture-checkbox',
+  description: '都道府県チェックボックスのスタイル',
+  jsx: ['PrefectureCheckbox'],
+  slots: ['label'],
+  base: {
+    label: {
+      pos: 'relative',
+      display: 'flex',
+      flexDir: 'row',
+      justifyContent: 'start',
+      alignItems: 'center',
+      p: '1',
+      gap: '2.5',
+      rounded: 'lg',
+      '&:has(input:checked)': {
+        bg: 'primary.2',
+        color: 'primary.11',
+      },
+      '&:has(input:disabled)': {
+        color: 'keyplate.11',
+        cursor: 'not-allowed',
+      },
+      '&:has(input:checked:disabled)': {
+        bg: 'keyplate.2',
+        color: 'keyplate.11',
+      },
+      _hover: {
+        bg: 'keyplate.3',
+        '&:has(input:checked)': {
+          bg: 'primary.3',
+        },
+        '&:has(input:checked:disabled)': {
+          bg: 'keyplate.2',
+          color: 'keyplate.11',
+        },
+      },
+    },
+  },
+});

--- a/apps/web/src/features/navigation/components/PrefectureCheckbox/PrefectureCheckbox.tsx
+++ b/apps/web/src/features/navigation/components/PrefectureCheckbox/PrefectureCheckbox.tsx
@@ -7,7 +7,8 @@ import { Checkbox } from '@/components/Checkbox/Checkbox';
 import type { CheckboxProps } from '@/components/Checkbox/Checkbox';
 import { prefCodesSchema } from '@/models/prefCode';
 import type { PrefCode } from '@/models/prefCode';
-import { css, cx } from 'styled-system/css';
+import { cx } from 'styled-system/css';
+import { prefectureCheckbox } from 'styled-system/recipes';
 
 /**
  * 指定された都道府県コードが選択されているかどうかをsearchParamsから判定して返すカスタムフックです。
@@ -125,46 +126,9 @@ export const PrefectureCheckbox = ({
 
   const checkboxId = `prefecture-${prefCode}`;
   const actualLabelId = `prefecture-${prefCode}-label`;
+  const { label } = prefectureCheckbox();
   return (
-    <label
-      id={actualLabelId}
-      htmlFor={checkboxId}
-      className={cx(
-        css({
-          pos: 'relative',
-          display: 'flex',
-          flexDir: 'row',
-          justifyContent: 'start',
-          alignItems: 'center',
-          p: '1',
-          gap: '2.5',
-          rounded: 'lg',
-          '&:has(input:checked)': {
-            bg: 'primary.2',
-            color: 'primary.11',
-          },
-          '&:has(input:disabled)': {
-            color: 'keyplate.11',
-            cursor: 'not-allowed',
-          },
-          '&:has(input:checked:disabled)': {
-            bg: 'keyplate.2',
-            color: 'keyplate.11',
-          },
-          _hover: {
-            bg: 'keyplate.3',
-            '&:has(input:checked)': {
-              bg: 'primary.3',
-            },
-            '&:has(input:checked:disabled)': {
-              bg: 'keyplate.2',
-              color: 'keyplate.11',
-            },
-          },
-        }),
-        className,
-      )}
-    >
+    <label id={actualLabelId} htmlFor={checkboxId} className={cx(label, className)}>
       <Checkbox id={checkboxId} aria-labelledby={actualLabelId} checked={checked} onChange={handleChange} {...props} />
       {prefLocale}
     </label>

--- a/apps/web/src/styles/fonts/index.ts
+++ b/apps/web/src/styles/fonts/index.ts
@@ -4,6 +4,7 @@ export const calSans = localFont({
   src: './CalSans-SemiBold.woff2',
   display: 'swap',
   variable: '--font-cal-sans',
+  preload: false,
 });
 
 export const fontVariables = `${calSans.variable}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@pandacss/dev':
         specifier: 0.36.1
         version: 0.36.1(jsdom@24.0.0)(typescript@5.4.3)
+      '@pandacss/preset-panda':
+        specifier: 0.39.2
+        version: 0.39.2
       '@playwright/test':
         specifier: 1.44.1
         version: 1.44.1
@@ -3221,6 +3224,12 @@ packages:
       '@pandacss/types': 0.36.1
     dev: true
 
+  /@pandacss/preset-panda@0.39.2:
+    resolution: {integrity: sha512-TJPjxfojKSnt8TCm3elugw/SPoa2HLWSkyuYp+/EphV46O7buyYjwuqIDcOdqqdv4Rxa/7zwsVVhzwgdtpn4MQ==}
+    dependencies:
+      '@pandacss/types': 0.39.2
+    dev: true
+
   /@pandacss/shared@0.30.2:
     resolution: {integrity: sha512-3i+IpzorSqfbyoAtJmqoCJu9HjdIKLIQ3HJbHx0RROnvYuaSBU2LS7br8Ghq1IcAjj9kIvy4fp7vTOvzbZRYuQ==}
     dev: false
@@ -3270,6 +3279,10 @@ packages:
 
   /@pandacss/types@0.36.1:
     resolution: {integrity: sha512-F0mGFtXT2j1hNFi5Z1AXPxEYcHoaedyJyScEbsGga4aa2KlJCEPEX9UDdgltMlrhSilM7nq7RbrDMToZ/cwvOg==}
+    dev: true
+
+  /@pandacss/types@0.39.2:
+    resolution: {integrity: sha512-A+urImQjBGVTu2sAajgDToHnk+QPtsvxgqHIdtQjwIs59u4RI35JB4OXoy1Vb2ctUOJhuYmJSo/tWW4yR4S5ww==}
     dev: true
 
   /@pkgjs/parseargs@0.11.0:


### PR DESCRIPTION
- refactor: ♻️ (`<Checkbox>` `<PrefectureCheckbox>`) CSSスタイルをレシピとして定義するよう変更した。  (#32)
- chore: 🔧 (web) 未使用の色トークンを削除した。  (#32)
- refactor: ♻️ (web) フォントの事前読み込みを無効化した。  (#32)
