### PR TITLE
fix: 🐛 (`<PrefectureCheckbox>`) ラベルがカーソルの見た目をポインターにするように修正した。  (#64)

### DIFF
--- a/apps/web/src/features/navigation/components/PrefectureCheckbox/PrefectureCheckbox.recipe.tsx
+++ b/apps/web/src/features/navigation/components/PrefectureCheckbox/PrefectureCheckbox.recipe.tsx
@@ -15,6 +15,7 @@ export const prefectureCheckboxSlotRecipe = sva({
       p: '1',
       gap: '2.5',
       rounded: 'lg',
+      cursor: 'pointer',
       '&:has(input:checked)': {
         bg: 'primary.2',
         color: 'primary.11',


### PR DESCRIPTION
- close #64